### PR TITLE
Bump dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ google-services.json
 
 # Android Profiling
 *.hprof
+
+# Kotlin cache folder used by kotlin 2.0.0
+.kotlin

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,13 +2,14 @@ plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.android.library) apply false
     alias(libs.plugins.compose) apply false
+    alias(libs.plugins.compose.compiler) apply false
     alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.kotlin.multiplatform) apply false
 }
 
 allprojects {
     group = "dev.materii.pullrefresh"
-    version = "1.4.0-beta02"
+    version = "1.4.0-beta03"
 
     repositories {
         repositories {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,21 +1,22 @@
 [versions]
 agp = "8.2.2"
-kotlin = "1.9.22"
-compose-multiplatform = "1.6.0-beta02"
+kotlin = "2.0.0"
+compose-multiplatform = "1.6.11"
 compose-compiler = "1.5.8"
-core-ktx = "1.12.0"
+core-ktx = "1.13.1"
 
 [libraries]
 core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "core-ktx" }
-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version = "2.7.0" }
-activity-compose = { group = "androidx.activity", name = "activity-compose", version = "1.8.2" }
-material3 = { group = "androidx.compose.material3", name = "material3", version = "1.2.0-rc01" }
-material-icons-extended = { group = "androidx.compose.material", name = "material-icons-extended", version = "1.6.0" }
+lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version = "2.8.1" }
+activity-compose = { group = "androidx.activity", name = "activity-compose", version = "1.9.0" }
+material3 = { group = "androidx.compose.material3", name = "material3", version = "1.2.1" }
+material-icons-extended = { group = "androidx.compose.material", name = "material-icons-extended", version = "1.6.7" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 android-library = { id = "com.android.library", version.ref = "agp" }
 compose = { id = "org.jetbrains.compose", version.ref = "compose-multiplatform" }
+compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
 

--- a/pullrefresh/build.gradle.kts
+++ b/pullrefresh/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.compose)
+    alias(libs.plugins.compose.compiler)
     alias(libs.plugins.kotlin.multiplatform)
     id("maven-publish")
     id("signing")


### PR DESCRIPTION
The compose multiplatform version needed to be bumped to be compatible with projects using kotlin 2.0.0 and related compose versions. Bump other dependencies at the same time.

Bump kotlin and compose according to:  https://www.jetbrains.com/help/kotlin-multiplatform-dev/compose-compiler.html#migrating-a-compose-multiplatform-project

Fixes the issue where a project which has already been updated using this library gets the error: https://github.com/JetBrains/compose-multiplatform/issues/4277
