### PR TITLE
Fix: Upward scroll fling value not consumed when refresh callback is …

### DIFF
--- a/demo/build.gradle.kts
+++ b/demo/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
+    alias(libs.plugins.compose.compiler)
 }
 
 android {
@@ -38,9 +39,6 @@ android {
     }
     buildFeatures {
         compose = true
-    }
-    composeOptions {
-        kotlinCompilerExtensionVersion = libs.versions.compose.compiler.get()
     }
     packaging {
         resources {

--- a/demo/src/main/java/dev/materii/pullrefresh/demo/MainActivity.kt
+++ b/demo/src/main/java/dev/materii/pullrefresh/demo/MainActivity.kt
@@ -136,6 +136,7 @@ class MainActivity : ComponentActivity() {
                                     flipped = flipped,
                                     pullRefreshState = pullRefreshState,
                                     modifier = Modifier.fillMaxSize(),
+                                    isRefreshing = isRefreshing
                                 )
                             }
                         }

--- a/demo/src/main/java/dev/materii/pullrefresh/demo/sample/DragRefreshSample.kt
+++ b/demo/src/main/java/dev/materii/pullrefresh/demo/sample/DragRefreshSample.kt
@@ -1,23 +1,26 @@
 package dev.materii.pullrefresh.demo.sample
 
-import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import dev.materii.pullrefresh.DragRefreshLayout
+import androidx.compose.ui.unit.dp
 import dev.materii.pullrefresh.DragRefreshIndicator
+import dev.materii.pullrefresh.DragRefreshLayout
 import dev.materii.pullrefresh.PullRefreshState
 
 @Composable
 fun DragRefreshSample(
     flipped: Boolean,
     pullRefreshState: PullRefreshState,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    isRefreshing: Boolean
 ) {
     DragRefreshLayout(
         modifier = modifier,
@@ -31,13 +34,22 @@ fun DragRefreshSample(
             )
         }
     ) {
-        Box(
-            modifier = Modifier
-                .fillMaxSize()
-                .verticalScroll(rememberScrollState()),
-            contentAlignment = Alignment.Center
+        LazyColumn(
+            Modifier.fillMaxSize(),
+            userScrollEnabled = !isRefreshing
         ) {
-            Text(text = "Pull ${if (flipped) "up" else "down"} to refresh")
+            items(100) {
+                Text(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(5.dp)
+                        .background(
+                            color = MaterialTheme.colorScheme.outline,
+                            shape = RoundedCornerShape(10.dp)
+                        )
+                        .padding(10.dp), text = "No. $it"
+                )
+            }
         }
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,6 @@
 agp = "8.2.2"
 kotlin = "2.0.0"
 compose-multiplatform = "1.6.11"
-compose-compiler = "1.5.8"
 core-ktx = "1.13.1"
 
 [libraries]

--- a/pullrefresh/src/commonMain/kotlin/dev/materii/pullrefresh/PullRefreshState.kt
+++ b/pullrefresh/src/commonMain/kotlin/dev/materii/pullrefresh/PullRefreshState.kt
@@ -125,7 +125,8 @@ class PullRefreshState internal constructor(
     internal fun onRelease(velocity: Float): Float {
         if (refreshing) return 0f // Already refreshing, do nothing
 
-        if (adjustedDistancePulled > threshold) {
+        val isRefreshTiming = adjustedDistancePulled > threshold
+        if (isRefreshTiming) {
             onRefreshState.value()
         }
         animateIndicatorTo(0f)
@@ -133,9 +134,14 @@ class PullRefreshState internal constructor(
             // We are flinging without having dragged the pull refresh (for example a fling inside
             // a list) - don't consume
             distancePulled == 0f -> 0f
-            // If the velocity is negative, the fling is upwards, and we don't want to prevent the
-            // the list from scrolling
-            velocity < 0f -> 0f
+            velocity < 0f -> if (isRefreshTiming) {
+                // We need to prevent the fling upward when the refresh starts.
+                velocity
+            }else {
+                // If the velocity is negative, the fling is upwards, and we don't want to prevent
+                // the list from scrolling
+                0f
+            }
             // We are showing the indicator, and the fling is downwards - consume everything
             else -> velocity
         }


### PR DESCRIPTION
…called (#16)

* Fix the wrong compiler version for the demo project.

* [#15] Upward scroll fling value not consumed when refresh callback Is called

Consuming the fling value when the refresh starts since it holds no significant meaning in this context.

https://github.com/MateriiApps/pullrefresh/issues/15