### PR TITLE
Fix: Accept the feedback for the code style.

### DIFF
--- a/demo/src/main/java/dev/materii/pullrefresh/demo/MainActivity.kt
+++ b/demo/src/main/java/dev/materii/pullrefresh/demo/MainActivity.kt
@@ -135,8 +135,7 @@ class MainActivity : ComponentActivity() {
                                 1 -> DragRefreshSample(
                                     flipped = flipped,
                                     pullRefreshState = pullRefreshState,
-                                    modifier = Modifier.fillMaxSize(),
-                                    isRefreshing = isRefreshing
+                                    modifier = Modifier.fillMaxSize()
                                 )
                             }
                         }

--- a/demo/src/main/java/dev/materii/pullrefresh/demo/sample/DragRefreshSample.kt
+++ b/demo/src/main/java/dev/materii/pullrefresh/demo/sample/DragRefreshSample.kt
@@ -1,16 +1,14 @@
 package dev.materii.pullrefresh.demo.sample
 
-import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
 import dev.materii.pullrefresh.DragRefreshIndicator
 import dev.materii.pullrefresh.DragRefreshLayout
 import dev.materii.pullrefresh.PullRefreshState
@@ -19,8 +17,7 @@ import dev.materii.pullrefresh.PullRefreshState
 fun DragRefreshSample(
     flipped: Boolean,
     pullRefreshState: PullRefreshState,
-    modifier: Modifier = Modifier,
-    isRefreshing: Boolean
+    modifier: Modifier = Modifier
 ) {
     DragRefreshLayout(
         modifier = modifier,
@@ -34,22 +31,13 @@ fun DragRefreshSample(
             )
         }
     ) {
-        LazyColumn(
-            Modifier.fillMaxSize(),
-            userScrollEnabled = !isRefreshing
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState()),
+            contentAlignment = Alignment.Center
         ) {
-            items(100) {
-                Text(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(5.dp)
-                        .background(
-                            color = MaterialTheme.colorScheme.outline,
-                            shape = RoundedCornerShape(10.dp)
-                        )
-                        .padding(10.dp), text = "No. $it"
-                )
-            }
+            Text(text = "Pull ${if (flipped) "up" else "down"} to refresh")
         }
     }
 }

--- a/pullrefresh/src/commonMain/kotlin/dev/materii/pullrefresh/PullRefreshState.kt
+++ b/pullrefresh/src/commonMain/kotlin/dev/materii/pullrefresh/PullRefreshState.kt
@@ -134,13 +134,15 @@ class PullRefreshState internal constructor(
             // We are flinging without having dragged the pull refresh (for example a fling inside
             // a list) - don't consume
             distancePulled == 0f -> 0f
-            velocity < 0f -> if (isRefreshTiming) {
-                // We need to prevent the fling upward when the refresh starts.
-                velocity
-            }else {
-                // If the velocity is negative, the fling is upwards, and we don't want to prevent
-                // the list from scrolling
-                0f
+            velocity < 0f -> {
+                if (isRefreshTiming) {
+                    // We need to prevent the fling upward when the refresh starts.
+                    velocity
+                } else {
+                    // If the velocity is negative, the fling is upwards, and we don't want to prevent
+                    // the list from scrolling
+                    0f
+                }
             }
             // We are showing the indicator, and the fling is downwards - consume everything
             else -> velocity


### PR DESCRIPTION
This PR is for the acceptance of  #16 PR's requested changes!
Thank you for your feedback! @X1nto 

* A one-liner arrow for a multiline if seems weird, using blocks instead
    * https://github.com/MateriiApps/pullrefresh/pull/16#discussion_r1705263375

* Add a whitespace
    * https://github.com/MateriiApps/pullrefresh/pull/16#discussion_r1705263692

*  Change back DragRefreshSample.kt code to match with README.md
    * I rollback DragRefreshSample.kt code to [the commit](https://github.com/MateriiApps/pullrefresh/commit/a0056848348207bc51ad4a425c96ce39a0092efc) which is before [#16](https://github.com/MateriiApps/pullrefresh/pull/16) PR to match the sample code with README.md gif. 
    * The gif in README.md is as below
    
        <img src="https://github.com/MateriiApps/pullrefresh/raw/main/.github/images/pullrefresh-flipped.gif" width="200">
 
